### PR TITLE
Updating logger name to fix infinite recursion

### DIFF
--- a/uhp.py
+++ b/uhp.py
@@ -42,7 +42,7 @@ import time
 from datetime import datetime
 from uuid import uuid4
 
-logger = logging.getLogger('')
+logger = logging.getLogger('uhp')
 
 class UHPEvent():
     def __init__(self, src_ip, src_port, dest_ip, dest_port, action, message, tags=[], fields={}, session_id=None, signature=None):


### PR DESCRIPTION
Referencing the root logger in uhp.py can inadvertently pick up warning logs from hpfeeds.py when a socket failure occurs in hpfeeds. This can result in an infinite recursion, causing UHP to crash. By naming the logger in uhp.py "uhp," this resolves the issue.