### PR TITLE
Update for Python 3.14 / Ubuntu 26.04 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:26.04
 
 # You may want to change the uhp user id inside the container if
 # you're going to mount an external log directory.  The internal uid
@@ -11,8 +11,10 @@ FROM ubuntu:16.04
 # ... and make sure /var/log/uhp is writable by the uhp uid inside the container.
 ARG FOG_UID=903
 
-# Install packages
-RUN apt-get update && apt-get install -y git supervisor python3 authbind
+# Install packages.  python3-yaml comes from apt rather than pip because
+# Ubuntu 26.04 ships Python 3.14 with PEP 668 (externally-managed-environment),
+# which blocks system-wide pip installs.
+RUN apt-get update && apt-get install -y supervisor python3 python3-yaml authbind
 
 # What ports should we listen on, and what templates should we run?
 ARG LISTENERS=generic-listener:80

--- a/hpfeeds.py
+++ b/hpfeeds.py
@@ -284,7 +284,10 @@ class HPC_SSL(HPC):
 
 	def makesocket(self, addr_family):
 		s = socket.socket(addr_family, socket.SOCK_STREAM)
-		return ssl.wrap_socket(s, ca_certs=self.certfile, ssl_version=3, cert_reqs=2)
+		# ssl.wrap_socket() was removed in Python 3.12; use an SSLContext that
+		# verifies the broker against the supplied CA bundle (CERT_REQUIRED).
+		context = ssl.create_default_context(cafile=self.certfile)
+		return context.wrap_socket(s, server_hostname=self.host)
 
 
 def new(host=None, port=10000, ident=None, secret=None, timeout=3, reconnect=True, sleepwait=20, certfile=None):

--- a/uhp.py
+++ b/uhp.py
@@ -41,7 +41,7 @@ import sys
 import threading
 import time
 import yaml
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
 
 logger = logging.getLogger('uhp')
@@ -136,7 +136,7 @@ class UniversalHoneyPot():
                         input_, rule['pattern'], self.state, self.state)
                     )
                 # Add a {date} key for output
-                dt = datetime.utcnow()
+                dt = datetime.now(timezone.utc).replace(tzinfo=None)
                 output_fields = {}
                 if "datefmt" in rule:
                     date = dt.strftime(rule['datefmt'])
@@ -289,7 +289,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
             if log_entry:
                 self.log("send", log_entry.rstrip(), tags, fields)
             else:
-                self.log("noop", output, tags, fields)
+                self.log("noop", "", tags, fields)
 
 
     def handle(self):
@@ -323,7 +323,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
         # Write out the banner if there is one
         if self.machine.banner:
             # Set up the date so we can output it in the banner if needed
-            dt = datetime.utcnow()
+            dt = datetime.now(timezone.utc).replace(tzinfo=None)
             if "datefmt" in self.server.config:
                 date = dt.strftime(self.server.config['datefmt'])
             else:
@@ -345,7 +345,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
                     continue
 
                 # Check to see if we've exceeded max bytes, and truncate if so
-                if server.max_bytes:
+                if self.server.max_bytes:
                     if len(line) > bytes_remaining:
                         line = line[0:bytes_remaining]
                         self.machine.truncated = True
@@ -436,22 +436,16 @@ class SSLTCPServer(socketserver.TCPServer):
     def __init__(self,
                  server_address,
                  RequestHandlerClass,
-                 certfile,
-                 keyfile,
-                 ssl_version=ssl.PROTOCOL_TLSv1_2,
+                 ssl_context,
                  bind_and_activate=True):
         socketserver.TCPServer.__init__(self, server_address, RequestHandlerClass, bind_and_activate)
-        self.certfile = certfile
-        self.keyfile  = keyfile
-        self.ssl_version = ssl_version
+        self.ssl_context = ssl_context
 
     def get_request(self):
         newsocket, fromaddr = self.socket.accept()
-        connstream = ssl.wrap_socket(newsocket,
-                                 server_side=True,
-                                 certfile = self.certfile,
-                                 keyfile = self.keyfile,
-                                 ssl_version = self.ssl_version)
+        # ssl.wrap_socket() was removed in Python 3.12, so wrap via the
+        # SSLContext.wrap_socket() method, which is available from 3.6 onward.
+        connstream = self.ssl_context.wrap_socket(newsocket, server_side=True)
         return connstream, fromaddr
 
 class SSLThreadedTCPServer(socketserver.ThreadingMixIn, SSLTCPServer):
@@ -548,34 +542,6 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    # Parse TLS arguments
-    try:
-        # Default to max version of TLS the client supports
-        # Works in Python 3.6+
-        ssl_version = ssl.PROTOCOL_TLS
-    except:
-        # Fall back for older Python
-        ssl_version = ssl.PROTOCOL_TLSv1_2
-
-    if args.tls_version:
-        try:
-            if args.tls_version == "1.3":
-                ssl_version = ssl.PROTOCOL_TLSv1_3
-            if args.tls_version == "1.2":
-                ssl_version = ssl.PROTOCOL_TLSv1_2
-            elif args.tls_version == "1.1":
-                ssl_version = ssl.PROTOCOL_TLSv1_1
-            elif args.tls_version == "1.0" or args.tls_version == "1":
-                ssl_version = ssl.PROTOCOL_TLSv1
-            elif args.tls_version == "3":
-                # Requires an older version of openssl
-                ssl_version = ssl.PROTOCOL_SSLv3
-            else:
-                parser.error("Unsupported TLS version: " + args.tls_version)
-        except AttributeError:
-            print("SSL/TLS v" + args.tls_version + " is not supported by this version of the ssl library.")
-            sys.exit(1)
-
     # TLS certificate and key files
     enable_tls = False
     if args.key_file and not args.cert_file:
@@ -593,6 +559,35 @@ if __name__ == "__main__":
             print(e)
             sys.exit(1)
         enable_tls = True
+
+    # Build the TLS context.  ssl.wrap_socket() and the standalone
+    # PROTOCOL_TLSv1* constants are deprecated/removed in modern Python, so we
+    # use an SSLContext.  PROTOCOL_TLS_SERVER is available from Python 3.6 on.
+    ssl_context = None
+    if enable_tls:
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        ssl_context.load_cert_chain(certfile=args.cert_file, keyfile=args.key_file)
+
+        # Pin a specific TLS version if requested.  Setting min == max version
+        # via ssl.TLSVersion requires Python 3.7+; on 3.6 we fall back to the
+        # library's negotiated default.
+        if args.tls_version:
+            if hasattr(ssl, "TLSVersion"):
+                version_map = {
+                    "1.3": ssl.TLSVersion.TLSv1_3,
+                    "1.2": ssl.TLSVersion.TLSv1_2,
+                    "1.1": ssl.TLSVersion.TLSv1_1,
+                    "1.0": ssl.TLSVersion.TLSv1,
+                    "1":   ssl.TLSVersion.TLSv1,
+                }
+                tls_version = version_map.get(args.tls_version)
+                if tls_version is None:
+                    parser.error("Unsupported TLS version: " + args.tls_version)
+                ssl_context.minimum_version = tls_version
+                ssl_context.maximum_version = tls_version
+            else:
+                print("Pinning a specific TLS version requires Python 3.7+; "
+                      "using the library default instead.")
 
     # Configure logging
     logger.setLevel(logging.DEBUG)
@@ -674,8 +669,7 @@ if __name__ == "__main__":
     for port in args.port:
         if enable_tls:
             server = SSLThreadedTCPServer((args.bind_host, port),
-                                    ThreadedTCPRequestHandler, args.cert_file, args.key_file,
-                                    ssl_version)
+                                    ThreadedTCPRequestHandler, ssl_context)
         else:
             server = ThreadedTCPServer((args.bind_host, port),
                           ThreadedTCPRequestHandler)


### PR DESCRIPTION
Replace ssl.wrap_socket() (removed in Python 3.12) with ssl.SSLContext and the context.wrap_socket() method, which works on both Python 3.6.8 (system) and 3.14 (Ubuntu 26.04). The __main__ TLS block now builds an SSLContext and pins TLS versions via ssl.TLSVersion when available (3.7+), falling back to the library default otherwise. Drop the dead SSLv3 and nonexistent PROTOCOL_TLSv1_3-constant paths.

Replace deprecated datetime.utcnow() with datetime.now(timezone.utc), keeping the existing naive-UTC output format.

Update Dockerfile to FROM ubuntu:26.04 and install python3-yaml via apt (the previous build never installed PyYAML, and PEP 668 on 26.04 blocks system-wide pip); drop the unused git package.

Also fix two latent bugs: an undefined 'output' in write_to_client's noop log path, and a module-global 'server' reference instead of self.server in handle().