### PR TITLE
Add honeypot config emulating CVE-2024-3273 (D-Link NAS RCE)

### DIFF
--- a/configs/CVE-2024-3273/CVE-2024-3273.yml
+++ b/configs/CVE-2024-3273/CVE-2024-3273.yml
@@ -1,0 +1,57 @@
+# Honeypot emulating CVE-2024-3273 - D-Link NAS (DNS-320L/325/327L/340L)
+# unauthenticated command injection via nas_sharing.cgi 'system' parameter
+# combined with the hardcoded 'messagebus' backdoor account.
+# UHP cannot execute the injected command; it captures the base64 payload
+# for intel and returns a canned "vulnerable device" 200 response.
+---
+fields:
+  app: uhp
+  emulated: D-Link DNS-320L
+  cve: CVE-2024-3273
+datefmt: '%a, %d %b %Y %H:%M:%S GMT'
+states:
+  _START:
+  # Exploit: command injection through the base64 'system' parameter.
+  # Capture the payload (base64 cmd) for logging. match[0] is the HTTP method
+  # (group 1), match[1] is the base64 payload (group 2). Note: UHP field
+  # substitution only exposes positional {match[N]} groups, not named groups.
+  - pattern: '^(GET|POST) /cgi-bin/nas_sharing.cgi\?.*system=([^&\s]+)'
+    fields:
+      cmd_b64: '{match[1]}'
+    tags:
+    - exploit
+    - cve-2024-3273
+    next: http-cgi-200
+  # Recon / backdoor probe to the CGI without an injected command.
+  - pattern: '^(GET|POST) /cgi-bin/nas_sharing.cgi'
+    tags:
+    - fingerprint
+    next: http-cgi-200
+  # Everything else -> 404 (still records the request line in the session log).
+  - pattern: .*
+    next: http-404
+  # Wait for the end of the request headers (blank line), then respond.
+  http-cgi-200:
+  - pattern: ^$
+    output: "HTTP/1.1 200 OK\r\nServer: lighttpd/1.4.28\r\nContent-Type: text/xml\r\nConnection: close\r\n\r\n"
+    file: configs/CVE-2024-3273/nas_sharing.xml
+    next: _END
+  http-404:
+  - pattern: ^$
+    output: "HTTP/1.1 404 Not Found\r\nServer: lighttpd/1.4.28\r\nContent-Type: text/html\r\nConnection: close\r\n\r\n"
+    file: configs/CVE-2024-3273/notfound.txt
+    next: _END
+  # Ignore highly variable headers so identical attacks share one signature,
+  # and capture the User-Agent for fingerprinting (mirrors CVE-2020-3452.yml).
+  _SHARED:
+  - pattern: '^Host:'
+    tags:
+    - am_ignore
+  - pattern: '^Content-Length:'
+    tags:
+    - am_ignore
+  - pattern: '^User-Agent: ?(.*)'
+    fields:
+      ua: '{match[0]}'
+    tags:
+    - am_ignore

--- a/configs/CVE-2024-3273/nas_sharing.xml
+++ b/configs/CVE-2024-3273/nas_sharing.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<postxml>
+<result>SUCCESS</result>
+<totalcount>0</totalcount>
+</postxml>

--- a/configs/CVE-2024-3273/notfound.txt
+++ b/configs/CVE-2024-3273/notfound.txt
@@ -1,0 +1,1 @@
+<html><head><title>404 Not Found</title></head><body><h1>404 Not Found</h1></body></html>


### PR DESCRIPTION
Simulates the unauthenticated command-injection / hardcoded-backdoor flaw in end-of-life D-Link NAS devices (DNS-320L/325/327L/340L) via nas_sharing.cgi's base64 'system' parameter and the 'messagebus' account.

The state machine matches the exploit request, captures the attacker's base64 payload into a cmd_b64 log field, tags it exploit/cve-2024-3273, and returns a believable lighttpd 200 + XML response. CGI recon hits get a fingerprint-tagged 200 and everything else a 404.